### PR TITLE
Start final visualization

### DIFF
--- a/assets/css/visualization-graph.css
+++ b/assets/css/visualization-graph.css
@@ -1,10 +1,30 @@
 text {
 	font-family: sans-serif;
-	fill: #777;
+	fill: rgb(200, 200, 200);
+	text-anchor: start;
 }
 
 circle {
 	stroke: #777;
 	stroke-width: 1;
 	fill: none;
+}
+
+text {
+	fill: rgb(200, 200, 200);
+	font-size: 4px;
+	text-anchor: start;
+}
+
+.link {
+	fill: none;
+	stroke-width: 0.07;
+}
+
+.person {
+	fill: grey;
+}
+
+.source {
+	fill: grey;
 }

--- a/src/GraphPlot.js
+++ b/src/GraphPlot.js
@@ -1,21 +1,63 @@
 class GraphPlot {
 	constructor(/**HTMLElement*/ container) {
-		this.container = d3.select(container);
 		this.simulation = new GraphSimulation();
-
-		this.container
-			.append("circle")
-			.attr("cx", 0)
-			.attr("cy", 0)
-			.attr("r", 230);
-
-		this.container
-			.append("text")
-			.attr("x", 0)
-			.attr("y", 0)
-			.attr("text-anchor", "middle")
-			.text("[Graph here]");
+		this.createScale();
+		this.createGraph(container);
 	}
 
-	async setTimeRange(/**number*/ year, /**number*/ month, /**number*/ day) {}
+	createScale() {
+		const tmpScale = d3
+			.scalePow()
+			.exponent(0.3)
+			.domain([-10, 10])
+			.range([1, 0]);
+		this.toneScale = d => d3.interpolateRdYlGn(tmpScale(d));
+	}
+
+	createGraph(/**HTMLElement*/ container) {
+		this.svgEl = d3.select(container);
+		this.linksGroup = this.svgEl.append("g").attr("id", "links");
+		this.nodesGroup = this.svgEl.append("g").attr("id", "nodes");
+	}
+
+	updateData(/**{nodes: array, links: array}*/ data) {
+		const linksJoin = this.linksGroup.selectAll("path").data(data.links);
+		const linksEls = linksJoin
+			.enter()
+			.append("path")
+			.classed("link", true)
+			.attr("stroke", d => this.toneScale(d["tone"]));
+		linksJoin.exit().remove();
+
+		const nodesJoin = this.nodesGroup.selectAll("circle").data(data.nodes);
+		const nodesEls = nodesJoin
+			.enter()
+			.append("circle")
+			.attr("r", 1)
+			.attr("class", d => "node " + d.type);
+		nodesJoin.exit().remove();
+
+		this.simulation.updateData(data);
+		this.simulation.onTick(() => {
+			nodesEls.attr("transform", d => `translate(${d.x}, ${d.y})`);
+			linksEls.attr("d", GraphPlot.linkAvoidCenter);
+		});
+	}
+
+	static linkAvoidCenter(/**object*/ link) {
+		const targetv = Victor.fromObject(link.target);
+		const sourcev = Victor.fromObject(link.source);
+
+		let angleDiff = targetv.angleDeg() - sourcev.angleDeg();
+		if (Math.abs(angleDiff) > 180) {
+			angleDiff = mod(angleDiff + 180, 360) - 180;
+		}
+		sourcev.rotateDeg(angleDiff / 2);
+
+		const scale = (Math.abs(angleDiff) / 180 / 3) * 8 + 1;
+		sourcev.multiply(new Victor(scale, scale));
+
+		return `M${link.target.x} ${link.target.y}
+                S${sourcev.x} ${sourcev.y}, ${link.source.x} ${link.source.y}`;
+	}
 }

--- a/src/GraphSimulation.js
+++ b/src/GraphSimulation.js
@@ -1,3 +1,32 @@
 class GraphSimulation {
-	constructor() {}
+	constructor() {
+		const linksForce = d3
+			.forceLink()
+			.id(d => d.id)
+			.strength(d => d.tone / 10000)
+			.distance(50);
+
+		const chargeForce = d3
+			.forceManyBody()
+			.strength(node => (node.type === "source" ? 0.1 : -2));
+
+		const radialForce = d3
+			.forceRadial(node => (node.type === "source" ? 200 : 100))
+			.strength(2.0);
+
+		this._simulation = d3
+			.forceSimulation()
+			.force("links", linksForce)
+			.force("charge", chargeForce)
+			.force("radial", radialForce);
+	}
+
+	onTick(/**function*/ callback) {
+		this._simulation.on("tick", callback);
+	}
+
+	updateData(/**{nodes: array, links: array}*/ data) {
+		this._simulation.nodes(data.nodes);
+		this._simulation.force("links").links(data.links);
+	}
 }

--- a/src/getData.js
+++ b/src/getData.js
@@ -1,0 +1,23 @@
+async function getData(/**number*/ year, /**number*/ month, /**number*/ day) {
+	const mentions = await d3.csv("data/mentions.csv");
+	const mainSources = await d3.csv("data/sources.csv");
+
+	const sources = get_unique_values(mentions, "source_index").map(source_index => ({
+		type: "source",
+		name: mainSources[source_index],
+		id: source_index
+	}));
+	const persons = get_unique_values(mentions, "person").map(name => ({
+		type: "person",
+		id: name
+	}));
+	const nodes = persons.concat(sources);
+
+	const links = mentions.map(mention => ({
+		source: mention["source_index"],
+		target: mention["person"],
+		tone: mention["tone_avg"]
+	}));
+
+	return { nodes, links };
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,2 +1,9 @@
 const graphPlot = new GraphPlot(document.getElementById("plot"));
 const sidebar = new Sidebar(document.getElementById("sidebar"), graphPlot);
+
+async function init() {
+	const data = await getData(2018, 12, 11);
+	graphPlot.updateData(data);
+}
+
+init().catch(console.error);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+function get_unique_values(data, field) {
+	return [...d3.rollup(data, _ => undefined, d => d[field]).keys()];
+}
+
+function mod(a, n) {
+	return ((a % n) + n) % n;
+}

--- a/visualization.html
+++ b/visualization.html
@@ -19,16 +19,15 @@
 			<div id="sidebar"></div>
 		</main>
 
-		<script
-			src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.7.0/d3.min.js"
-			integrity="sha256-va1Vhe+all/yVFhzgwmwBgWMVfLHjXlNJfvsrjUBRgk="
-			crossorigin="anonymous"
-		></script>
+		<script src="https://d3js.org/d3.v5.js"></script>
+		<script src="https://d3js.org/d3-array.v2.min.js"></script>
 		<script
 			src="https://cdnjs.cloudflare.com/ajax/libs/victor/1.1.0/victor.min.js"
 			integrity="sha256-QH04jkqJgJzblmzmCljNPAANQK9jgSJDKDow2piEYdQ="
 			crossorigin="anonymous"
 		></script>
+		<script src="src/utils.js"></script>
+		<script src="src/getData.js"></script>
 		<script src="src/GraphPlot.js"></script>
 		<script src="src/GraphSimulation.js"></script>
 		<script src="src/Sidebar.js"></script>


### PR DESCRIPTION
Hi guys,

As promised, I continued to work on the code for the visualization. This is still very rudimentary: no controls, no selection, no dragging for now.

![screen shot 2018-12-11 at 22 58 02](https://user-images.githubusercontent.com/777748/49833088-c8c4d800-fd98-11e8-8f64-b22d8f014642.png)

This is an adaption of [Ruslan's code](https://github.com/mbovel/dataviz-project/blob/master/processbook/week11/sources_events_graph_prototype/sources_events.js) with the following main differences:

- SVG elements references are stored in attributes or variables (for example`this.linksGroup`) so there is no need to reselect them (for example with `d3.select('#links')`).
- The origin is (0,0), consequently:
  - The `GraphSimulation` is independent of the center, so it doesn't need to access the SVG root to get its weight or height anymore.
  - The `GraphPlot.linkAvoidCenter` can also be simplified: no need to subtract or add the center point.
- `GraphSimulation` does not hold a reference to its “parent” object anymore. It subscribe to ticks trough `GraphSimulation.onTick`.
- After some thinking, and unlike what I said this morning, I merged `updatePlot` with its helper methods `updateSelection`, `exitSelection` and `enterSelection`. It simplifies the code by avoiding the need to store or pass around selections; they stay local.
- `getData` has been adapted for the new CSV format.
- The radius for circles is set from D3, so this fixes #15.

At this stage, I see two little problems which I think might be solved easily:

- There are too much nodes (so we need to filter them, by region or country, or by taking the ones with the most mentions for example).
- The links shape are not ideal right now. Ruslan's I'll let you adapt your `linkAvoidCenter` method if that's OK for you.